### PR TITLE
Fixed dump profiling

### DIFF
--- a/WebProfilerServiceProvider.php
+++ b/WebProfilerServiceProvider.php
@@ -376,6 +376,7 @@ class WebProfilerServiceProvider implements ServiceProviderInterface, Controller
         $dispatcher->addSubscriber($app['profiler']->get('request'));
 
         if (isset($app['var_dumper.data_collector'])) {
+            $app['var_dumper.dump_listener']->configure();
             $dispatcher->addSubscriber($app['var_dumper.dump_listener']);
         }
     }


### PR DESCRIPTION
Configuring the DumpListener before subscribing to its events, allowing it to correctly capture dump function calls in the WebProfilerToolbar